### PR TITLE
Swift 3 Access Control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+### 1.0.3
+- Swift 3 access control
+
 ### 1.0.0
 - Swift 3.0 support.
 - Dropped Swift 2.3 support.

--- a/CarambaKit/Classes/Foundation/Protocols/Adapter.swift
+++ b/CarambaKit/Classes/Foundation/Protocols/Adapter.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public class Adapter<I, O> {
+open class Adapter<I, O> {
 
     // MARK: - Public
 
     public init() {}
 
-    public func adapt(_ input: I) -> O! {
+    open func adapt(_ input: I) -> O! {
         assertionFailure("This method must be overriden")
         return nil
     }

--- a/CarambaKit/Classes/Networking/Client/HttpClient.swift
+++ b/CarambaKit/Classes/Networking/Client/HttpClient.swift
@@ -11,7 +11,7 @@ open class HttpClient<T> {
 
     // MARK: - Init
 
-    open init(responseAdapter: Adapter<(data: Data?, response: URLResponse?), (T, URLResponse?)>,
+    public init(responseAdapter: Adapter<(data: Data?, response: URLResponse?), (T, URLResponse?)>,
                 requestDispatcher: UrlRequestDispatcher = UrlRequestDispatcher(),
                 sessionAdapter: Adapter<URLRequest, URLRequest>? = nil) {
         self.responseAdapter = responseAdapter

--- a/CarambaKit/Classes/Networking/Client/HttpClient.swift
+++ b/CarambaKit/Classes/Networking/Client/HttpClient.swift
@@ -1,7 +1,7 @@
 import Foundation
 import RxSwift
 
-public class HttpClient<T> {
+open class HttpClient<T> {
 
     // MARK: - Attributes
 
@@ -11,7 +11,7 @@ public class HttpClient<T> {
 
     // MARK: - Init
 
-    public init(responseAdapter: Adapter<(data: Data?, response: URLResponse?), (T, URLResponse?)>,
+    open init(responseAdapter: Adapter<(data: Data?, response: URLResponse?), (T, URLResponse?)>,
                 requestDispatcher: UrlRequestDispatcher = UrlRequestDispatcher(),
                 sessionAdapter: Adapter<URLRequest, URLRequest>? = nil) {
         self.responseAdapter = responseAdapter
@@ -21,7 +21,7 @@ public class HttpClient<T> {
 
     // MARK: - Init
 
-    public func request(request: URLRequest) -> Observable<(T, URLResponse?)> {
+    open func request(request: URLRequest) -> Observable<(T, URLResponse?)> {
         var authenticatedRequest = self.sessionAdapter?.adapt(request) ?? request
         return self.requestDispatcher.dispatch(request: authenticatedRequest)
             .map({self.responseAdapter.adapt($0)!})

--- a/CarambaKit/Classes/Networking/Client/JsonHttpClient.swift
+++ b/CarambaKit/Classes/Networking/Client/JsonHttpClient.swift
@@ -2,7 +2,7 @@ import Foundation
 import RxSwift
 import SwiftyJSON
 
-public class JsonHttpClient: HttpClient<JSON> {
+open class JsonHttpClient: HttpClient<JSON> {
 
     // MARK: - Init
 

--- a/CarambaKit/Classes/Networking/Client/JsonHttpClient.swift
+++ b/CarambaKit/Classes/Networking/Client/JsonHttpClient.swift
@@ -10,7 +10,7 @@ open class JsonHttpClient: HttpClient<JSON> {
         super.init(responseAdapter: UrlJsonResponseAdapter.instance, requestDispatcher: requestDispatcher, sessionAdapter: sessionAdapter)
     }
 
-    override public func request(request: URLRequest) -> Observable<(JSON, URLResponse?)> {
+    override open func request(request: URLRequest) -> Observable<(JSON, URLResponse?)> {
         return super.request(request: self.requestWithJSONHeaders(request: request))
     }
 

--- a/CarambaKit/Classes/Networking/Client/UrlJsonResponseAdapter.swift
+++ b/CarambaKit/Classes/Networking/Client/UrlJsonResponseAdapter.swift
@@ -9,7 +9,7 @@ open class UrlJsonResponseAdapter: Adapter<(data: Data?, response: URLResponse?)
 
     // MARK: - Public
 
-    public override func adapt(_ input: (data: Data?, response: URLResponse?)) -> (JSON, URLResponse?)! {
+    open override func adapt(_ input: (data: Data?, response: URLResponse?)) -> (JSON, URLResponse?)! {
         let json = JSON(data: input.data ?? Data())
         return (json: json, response: input.response)
     }

--- a/CarambaKit/Classes/Networking/Client/UrlJsonResponseAdapter.swift
+++ b/CarambaKit/Classes/Networking/Client/UrlJsonResponseAdapter.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SwiftyJSON
 
-public class UrlJsonResponseAdapter: Adapter<(data: Data?, response: URLResponse?), (JSON, URLResponse?)> {
+open class UrlJsonResponseAdapter: Adapter<(data: Data?, response: URLResponse?), (JSON, URLResponse?)> {
 
     // MARK: - Singleton
 

--- a/CarambaKit/Classes/Networking/Client/UrlRequestDispatcher.swift
+++ b/CarambaKit/Classes/Networking/Client/UrlRequestDispatcher.swift
@@ -1,7 +1,7 @@
 import Foundation
 import RxSwift
 
-public class UrlRequestDispatcher {
+open class UrlRequestDispatcher {
 
     // MARK: - Attributes
 


### PR DESCRIPTION
### Short description

Updating access levels to make some classes and methods `open` instead of `public`. 
### GIF

![](https://media.giphy.com/media/l3vR9sjPQfJBUex9u/source.gif)
